### PR TITLE
feat(web): Sort classifiers by Overall Quality, Descending by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,5 @@ dump/
 dump.bak/
 
 # mongorestore
-2024-06-24.zip
+*.zip
 zeta

--- a/web/src/pages/ClassifiersPage/components/ClassifiersTable.jsx
+++ b/web/src/pages/ClassifiersPage/components/ClassifiersTable.jsx
@@ -35,7 +35,7 @@ const compactNumberColumnStyle = {
 };
 
 const ClassifiersTable = ({ division, onClassifierSelection }) => {
-  const sortProps = useTableSort({ initial: { field: "code", order: 1 } });
+  const sortProps = useTableSort({ initial: { field: "allDivQuality", order: -1 } });
   const [filter, setFilter] = useState("");
   const sortState = sortProps;
 


### PR DESCRIPTION
By default, sort the classifier's table by highest quality first.  This should hopefully result in match directors picking the higher quality classifiers since they are most visible by being at the top of the page by default.

**Testing Performed**:

`mongorestore`d into local db, visited classifiers page, and ensured that the classifiers were sorted by `OA. Qual` column, descending on page load.